### PR TITLE
Add parameter study utilities

### DIFF
--- a/parameter_study.py
+++ b/parameter_study.py
@@ -1,0 +1,121 @@
+"""Parameter study utilities for Mn flash smelting simulations."""
+
+from typing import List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from conceptual_mn_alloy_process_simulation import (
+    ManganesReductionSimulator,
+    ProcessParameters,
+)
+
+
+def parameter_study(params_list: List[ProcessParameters]) -> pd.DataFrame:
+    """Run simulations for multiple sets of process parameters.
+
+    Parameters
+    ----------
+    params_list:
+        List of :class:`ProcessParameters` instances representing different
+        operating conditions.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame summarising key outputs for each parameter set. Columns
+        include stage 1 temperature, Al content, Mn recovery and material
+        consumption metrics.
+    """
+
+    records = []
+
+    # Default compositions used for all simulations
+    initial_ore_composition = {
+        "MnO2": 50.0,
+        "Mn2O3": 15.0,
+        "Mn3O4": 5.0,
+        "MnO": 2.0,
+        "H2": 50.0,
+        "H2O": 0.0,
+    }
+
+    metal_bath_composition = {
+        "Al": 20.0,
+        "Fe": 80.0,
+        "Si": 8.0,
+        "Mn": 5.0,
+        "C": 2.0,
+    }
+
+    for params in params_list:
+        simulator = ManganesReductionSimulator(params)
+
+        stage1 = simulator.run_stage1_simulation(
+            initial_composition=initial_ore_composition,
+            time_range=(0, 5, 50),
+        )
+
+        stage1_output = {
+            "MnO": stage1["MnO"].iloc[-1],
+            "Mn3O4": stage1["Mn3O4"].iloc[-1],
+            "MnO2": stage1["MnO2"].iloc[-1],
+            "Mn2O3": stage1["Mn2O3"].iloc[-1],
+        }
+
+        stage2 = simulator.run_stage2_simulation(
+            stage1_output=stage1_output,
+            initial_metal_composition=metal_bath_composition,
+        )
+
+        metrics = simulator.calculate_overall_efficiency()
+
+        records.append(
+            {
+                "temperature_stage1": params.temperature_stage1,
+                "al_content": params.al_content,
+                "mn_recovery_kg": stage2.get("Mn_produced", 0.0),
+                "slag_Al2O3_kg": stage2.get("Al2O3_produced", 0.0),
+                "slag_MnO_remaining_kg": stage2.get("MnO_remaining", 0.0),
+                "h2_consumption_kg": metrics.get("h2_consumption_kg", 0.0),
+                "al_consumption_kg": metrics.get("al_consumption_kg", 0.0),
+                "overall_efficiency": metrics.get("overall_efficiency", 0.0),
+            }
+        )
+
+    return pd.DataFrame(records)
+
+
+def plot_recovery_vs_temperature(results: pd.DataFrame) -> None:
+    """Plot Mn recovery as a function of Stage 1 temperature."""
+
+    if results.empty:
+        print("No results to plot")
+        return
+
+    plt.figure()
+    plt.plot(results["temperature_stage1"], results["mn_recovery_kg"], "o-")
+    plt.xlabel("Stage 1 Temperature (K)")
+    plt.ylabel("Mn Recovery (kg)")
+    plt.title("Mn Recovery vs. Stage 1 Temperature")
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
+
+
+def plot_recovery_vs_al_content(results: pd.DataFrame) -> None:
+    """Plot Mn recovery as a function of Al content."""
+
+    if results.empty:
+        print("No results to plot")
+        return
+
+    plt.figure()
+    plt.plot(results["al_content"], results["mn_recovery_kg"], "s-")
+    plt.xlabel("Al Content in Bath (fraction)")
+    plt.ylabel("Mn Recovery (kg)")
+    plt.title("Mn Recovery vs. Al Content")
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
+

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -180,6 +180,35 @@ def test_full_process():
         traceback.print_exc()
         return False
 
+def test_parameter_study():
+    """Test the parameter study helper."""
+    print("\nTesting parameter study...")
+    try:
+        from conceptual_mn_alloy_process_simulation import ProcessParameters
+        from parameter_study import parameter_study, plot_recovery_vs_temperature, plot_recovery_vs_al_content
+        import matplotlib
+
+        # Use non-interactive backend for tests
+        matplotlib.use("Agg")
+
+        params_list = [
+            ProcessParameters(temperature_stage1=1100.0, al_content=0.10),
+            ProcessParameters(temperature_stage1=1200.0, al_content=0.20),
+        ]
+
+        results_df = parameter_study(params_list)
+        print(f"✓ Parameter study produced DataFrame with {len(results_df)} rows")
+
+        # Basic plotting calls to ensure functions execute
+        plot_recovery_vs_temperature(results_df)
+        plot_recovery_vs_al_content(results_df)
+
+        return True
+    except Exception as e:
+        print(f"✗ Parameter study test failed: {e}")
+        traceback.print_exc()
+        return False
+
 def main():
     """Run all tests"""
     print("=== CONCEPTUAL MN ALLOY PROCESS SIMULATION TESTS ===\n")
@@ -196,8 +225,9 @@ def main():
     
     stage2_success, _ = test_stage2_simulation()
     test_results.append(("Stage 2 Simulation", stage2_success))
-    
+
     test_results.append(("Complete Process", test_full_process()))
+    test_results.append(("Parameter Study", test_parameter_study()))
     
     # Summary
     print(f"\n=== TEST SUMMARY ===")


### PR DESCRIPTION
## Summary
- add `parameter_study` to run simulations for multiple parameter sets and collect key metrics in a DataFrame
- provide plotting helpers for Mn recovery versus temperature and Al content
- extend tests to cover parameter study and plotting utilities

## Testing
- `python test_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac6676dad8832b8d7574e904f2cdae